### PR TITLE
Changing delimiter to !

### DIFF
--- a/test-entries.ndjson
+++ b/test-entries.ndjson
@@ -2,6 +2,6 @@
 {"_id":"BTeam","_type":"team","title":"B-Team"}
 {"_id":"PersonOne","_type":"person","name":"Person One","email":"person1@example.com"}
 {"_id":"PersonTwo","_type":"person","name":"Person Two","email":"person2@example.com"}
-{"_id":"teamMembership-ATeam-PersonOne","_type":"teamMembership","team":"ATeam","person":"PersonOne"}
-{"_id":"teamMembership-ATeam-PersonTwo","_type":"teamMembership","team":"ATeam","person":"PersonTwo","startedAt":1428471302420}
-{"_id":"teamMembership-ATeam-PersonTwo","team":"ATeam","person":"PersonTwo","endedAt":1428471352420}
+{"_id":"teamMembership!ATeam!PersonOne","_type":"teamMembership","team":"ATeam","person":"PersonOne"}
+{"_id":"teamMembership!ATeam!PersonTwo","_type":"teamMembership","team":"ATeam","person":"PersonTwo","startedAt":1428471302420}
+{"_id":"teamMembership!ATeam!PersonTwo","team":"ATeam","person":"PersonTwo","endedAt":1428471352420}


### PR DESCRIPTION
Changing delimiters from `-` to `!`.

# Reason 1

I think `-` is a common char used in names. So with `!` as a delimiter, no need to worry about sanitising the key string. 

# Reason 2

From http://dailyjs.com/2013/05/03/leveldb-and-node-2/:

---
## Recommended delimiters

At the beginning of the printable ASCII character range is '!' (character code 33), and at the end we find '~' (character code 126). Using these characters as a delimiter we find the following sorting for our keys:

```
rod!...
rod.vagg!...
rod1977!...
roderick!...
```

or

```
rod.vagg~...
rod1977~...
roderick~...
rod~...
```
But why stick to the printable range? We can go right to the edges of the single-byte character range and use '\x00' (null) or '\xff' (ÿ).

For best sorting of your entries, choose '\x00' (or '!' if you really can’t stomach it). But whatever delimiter you choose, you’re still going to need to control the characters that can be used as keys. Allowing user-input to determine your keys and not stripping out your delimiter character could result in the NoSQL equivalent of an SQL Injection Attack (e.g. consider the unintended consequences that may arise with the dataset above with a delimiter of '!' and allowing a user to have that character in their username).

---
