### PR TITLE
Using dotenv package for env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# 1. Duplicate this file
+# 2. Remove the `.example` extension
+# 3. Get your own google application at:
+#    https://console.developers.google.com/project
+# 4. Edit the vars below according to the values you've got from the link above
+# 5. Save it.
+
+# NOTE: The `.env` file with your secrets is safely gitignored.
+
+# Base url for the website:
+BASE_URL=http://localhost:8000
+
+# Client ID for Google OAuth:
+GOOGLE_CLIENT=abcde12345
+
+# Secret for Google OAuth:
+GOOGLE_SECRET=fghij5678
+
+# And if you want to change the default port:
+# PORT=1234

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .sessions
 .sass-cache
 static/dist
+.env

--- a/config.js
+++ b/config.js
@@ -5,20 +5,8 @@
 Config
 ====
 
-Environment variables
-----
-
-To avoid committing passwords to the repo it's recommended to create a gitignored file called `setup-env`, eg.
-
-```
-export BASE_URL=http://localhost:8000
-export GOOGLE_CLIENT=...
-export GOOGLE_SECRET=...
-```
-
-Then to initialize the environment run `source setup-env`.
-
 */
+require('dotenv').load();
 let path = require('path');
 const config = {
   port: process.env.PORT || 8000,
@@ -30,12 +18,7 @@ const config = {
     Authentication
     ----
 
-    The environment variables needed for auth are:
-    - `GOOGLE_CLIENT` (clientID for google OAuth)
-    - `GOOGLE_SECRET` (secret for google OAuth)
-    - `BASE_URL` (base URL for the site, eg. `http://localhost:8000`)
-
-    For development you can create your own clienID and secret here: https://console.developers.google.com/project
+    The environment variables configuration needed for auth are are described in [./env.example](./.env.example) file.
 
   */
   auth: {

--- a/index.js
+++ b/index.js
@@ -41,5 +41,5 @@ require('./lib/setup-db')({ dbFile: config.dataDbFile }, function (err, db, docI
 
   // - start the http server
   httpServer.listen(config.port);
-  console.log('ready on :%d', config.port);
+  console.log('ready on http://localhost:%d', config.port);
 });

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bytewise": "^0.8.0",
     "concat-stream": "^1.4.8",
     "cuid": "^1.2.4",
+    "dotenv": "^1.1.0",
     "fingdex": "0.2.0",
     "generic-session": "^0.1.0",
     "hyperscript": "^1.4.6",


### PR DESCRIPTION
I also think that we could put the config instructions in the README, so the information for getting the app up and running are all centralized in one place. What do you think? Should we create an issue for that?.

NOTE: the second commit is just a sugar to make the localhost:8000 Cmd + clickable on iTerm :)